### PR TITLE
GitHub markdown support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'octopress', '~> 3.0.0.rc'
 gem 'aws-sdk-v1'
 gem 'jekyll-sitemap'
 gem 'octopress-escape-code'
+gem 'rouge'
 
 group :jekyll_plugins do
   gem 'octopress-multilingual'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.2)
+    rouge (1.9.1)
     safe_yaml (1.0.4)
     sass (3.4.15)
     timers (4.0.1)
@@ -97,3 +98,4 @@ DEPENDENCIES
   octopress (~> 3.0.0.rc)
   octopress-escape-code
   octopress-multilingual
+  rouge

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,9 @@ twitter_username: codeheaven_io
 
 # Build settings
 markdown: kramdown
+  
+kramdown:
+  input: GFM
 
 # Google Analytics info
 google_universal_analytics: UA-60941725-1

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ markdown: kramdown
   
 kramdown:
   input: GFM
+  syntax_highlighter: rouge
 
 # Google Analytics info
 google_universal_analytics: UA-60941725-1
@@ -25,6 +26,7 @@ google_universal_analytics_cookiedomain: auto
 gems:
   - octopress-escape-code
   - jekyll-sitemap
+  - rouge
 
 headers:
   - filename: '^assets.*\.js$'

--- a/_posts/2015-06-25-welcome-to-jekyll.markdown
+++ b/_posts/2015-06-25-welcome-to-jekyll.markdown
@@ -10,13 +10,13 @@ To add new posts, simply add a file in the `_posts` directory that follows the c
 
 Jekyll also offers powerful support for code snippets:
 
-{% highlight ruby %}
+```ruby
 def print_hi(name)
   puts "Hi, #{name}"
 end
 print_hi('Tom')
 #=> prints 'Hi, Tom' to STDOUT.
-{% endhighlight %}
+```
 
 Check out the [Jekyll docs][jekyll] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll’s dedicated Help repository][jekyll-help].
 


### PR DESCRIPTION
This PR adds support for writing our posts using GitHub Flavored Markdown (GFM). It allows us to wrap our code using the same syntax we use here. In other words, our posts will be easier to read when browsing the source code using GitHub.

I also set [rouge](http://rouge.jneen.net/) as our syntax highlighter. Rouge is a well-known syntax highlighter, made entirely in ruby and fully compatible with pygments. That means we can customize the code snippets theme using css.

Fix #7 
