### PR TITLE
Remove date from permalinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,8 @@ lang: en
 github_username: codeheaven-io
 twitter_username: codeheaven_io
 
+permalink: :title.html
+
 # Build settings
 markdown: kramdown
   

--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,8 @@ lang: en
 github_username: codeheaven-io
 twitter_username: codeheaven_io
 
-permalink: :title.html
+# 'none' has the same effect as /:categories/:title.html
+permalink: none
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
The default permalink format used by jekyll is: `/:categories/:year/:month/:day/:title.html`. That means that a post named _Intro to React_ would generate a permalink similar to this:

`http://codeheaven.io/2015/07/15/intro-to-react.html`

This PR changes the permalink format so it now is  `/:categories/:title.html`. It's very unlikely that we have collisions (two posts with the same title and category), but in case that happens, we could overwrite the permalink format or change the post's category.

Some URLs examples below:
- `http://codeheaven.io/intro-to-react.html` (post with title 'intro to react', without a category)
- `http://codeheaven.io/tutorials/intro-to-react.html` (post with title 'intro to react' and category as 'tutorials')
