### PR TITLE
Fix author display name in index

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -6,8 +6,8 @@ layout: default
     <li>
         <p class="post-meta">
           <time datetime="{{ post.date | date: '%Y-%m-%d' }}">{{ post.date | date: "%b %-d, %Y" }}</time>
-          • {{post.author}}
-          
+          • {{site.data.authors[post.author].name}}
+
         </p>
         <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">
           <h2 class="post-title">{{ post.title }}</h2>


### PR DESCRIPTION
I did this to use the display name registered in `authors.yml`, which was the original intent in #1 

Before (ignore the hover color):
![screen shot 2015-07-21 at 10 58 24 pm](https://cloud.githubusercontent.com/assets/4842605/8816394/b04efe94-2ffc-11e5-8354-d8465c104aac.png)

After:
![screen shot 2015-07-21 at 10 59 16 pm](https://cloud.githubusercontent.com/assets/4842605/8816405/d680fbda-2ffc-11e5-9a06-599d7cb39852.png)
