### PR TITLE
Use GothamBold as the font face for strong and b tags. Fix #15

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -14,6 +14,9 @@ article {
   }
 }
 
+b, strong {
+  font-family: $bold-font;
+}
 .page-header {
   margin: 0 -25% 3rem -25%;
   background-color: #f2f2f2;

--- a/_sass/config/_variables.scss
+++ b/_sass/config/_variables.scss
@@ -8,6 +8,7 @@ $code-border-radius: 0;
 /* Typography
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 $header-font: 'GothamBold', sans-serif;
+$bold-font: 'GothamBold', sans-serif;
 $default-font: 'GothamBook', sans-serif;
 $logo-font: "Merriweather", "PT Serif", Georgia, "Times New Roman", serif;
 $menu-font: "Merriweather", "PT Serif", Georgia, "Times New Roman", serif;


### PR DESCRIPTION
This PR fixes the font used for `strong` and `b` tags.

**Before**
![before](https://cloud.githubusercontent.com/assets/2975955/8848620/11f870d6-310f-11e5-98ae-f55e1e33a961.png)

**After**
![after](https://cloud.githubusercontent.com/assets/2975955/8848627/208d6e94-310f-11e5-9db4-775003984f50.png)

Fix #15 
