### PR TITLE
Add html-proofer and fix errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ _deploy.yml
 
 # RubyMine
 .idea/*
+
+# html-proofer
+tmp

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'aws-sdk-v1'
 gem 'jekyll-sitemap'
 gem 'octopress-escape-code'
 gem 'rouge'
+gem 'html-proofer'
 
 group :jekyll_plugins do
   gem 'octopress-multilingual'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,13 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    activesupport (4.2.5)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.4.0)
     aws-sdk-v1 (1.64.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -14,10 +21,23 @@ GEM
       execjs
     coffee-script-source (1.9.1.1)
     colorator (0.1)
+    colored (1.2)
+    ethon (0.8.1)
+      ffi (>= 1.3.0)
     execjs (2.5.2)
     fast-stemmer (1.0.2)
     ffi (1.9.8)
     hitimes (1.2.2)
+    html-proofer (2.6.1)
+      activesupport (~> 4.2)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
+    i18n (0.7.0)
     jekyll (2.5.3)
       classifier-reborn (~> 2.0)
       colorator (~> 0.1)
@@ -51,6 +71,7 @@ GEM
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
     mini_portile (0.6.2)
+    minitest (5.8.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     octopress (3.0.9)
@@ -69,6 +90,7 @@ GEM
       jekyll (>= 2.0)
     octopress-multilingual (1.2.0)
       octopress-hooks
+    parallel (1.6.1)
     parslet (1.5.0)
       blankslate (~> 2.0)
     posix-spawn (0.3.11)
@@ -82,20 +104,30 @@ GEM
     rouge (1.9.1)
     safe_yaml (1.0.4)
     sass (3.4.15)
+    thread_safe (0.3.5)
     timers (4.0.1)
       hitimes
     titlecase (0.1.1)
     toml (0.1.2)
       parslet (~> 1.5.0)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     yajl-ruby (1.2.1)
+    yell (2.0.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   aws-sdk-v1
+  html-proofer
   jekyll-sitemap
   octopress (~> 3.0.0.rc)
   octopress-escape-code
   octopress-multilingual
   rouge
+
+BUNDLED WITH
+   1.11.2

--- a/_ci/build
+++ b/_ci/build
@@ -2,3 +2,4 @@
 set -e # halt script on error
 
 bundle exec jekyll build
+bundle exec htmlproof ./_site --url-ignore http://localhost:8080

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: CodeHeaven
 email: codeheaven.io@gmail.com
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://codeheaven.io/"
+url: "http://codeheaven.io"
 author: codeheaven
 lang: en
 

--- a/_includes/author/links.html
+++ b/_includes/author/links.html
@@ -7,7 +7,7 @@
 {% assign author = site.data.authors[page_author] %}
 
 {% unless include.except_name %}
-<a rel="author" itemprop="author" onclick="_gaq.push(['_trackEvent', 'post_author', 'Post View', '{{ page.author }}'])"  href="{{ site.url }}authors/{{ page_author }}.html">{{ author.name }}</a>
+<a rel="author" itemprop="author" onclick="_gaq.push(['_trackEvent', 'post_author', 'Post View', '{{ page.author }}'])"  href="{{ site.url }}/authors/{{ page_author }}.html">{{ author.name }}</a>
   |
 {% endunless %}
 <a href="{{ site.data.resources.github }}{{ author.github }}" target="_blank">{{ author.github }}</a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -40,7 +40,7 @@
 
   <!-- Favicon
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link rel="icon" type="image/png" href="../../dist/images/favicon.png">
+  <!-- <link rel="icon" type="image/png" href="../../dist/images/favicon.png"> -->
 
   {% include google_analytics.html %}
 </head>

--- a/_layouts/talks.html
+++ b/_layouts/talks.html
@@ -14,7 +14,7 @@ layout: default
         -
         {% for media in talk.media %}
           <a class="talk-media-link" href="{{media.link}}">
-            <img src="/assets/images/flags/{{media.flag}}" width="17" height="13">
+            <img src="/assets/images/flags/{{media.flag}}" width="17" height="13" alt="media.flag">
             {{ media.description }}
           </a>
         {% endfor %}

--- a/_posts/2016-01-14-javascript-code-coverage-with-instanbul-and-coveralls.markdown
+++ b/_posts/2016-01-14-javascript-code-coverage-with-instanbul-and-coveralls.markdown
@@ -57,7 +57,7 @@ Run this script with `npm run coverage` and it will generate a `coverage` folder
 
 ## Code coverage insight service
 
-Just sign up to [https://coveralls.io/](Coveralls) and add the Github repo you want to watch.
+Just sign up to [Coveralls](https://coveralls.io/) and add the Github repo you want to watch.
 
 
 ## Coverage reporting tool


### PR DESCRIPTION
Adds html-proffer so the CI build will navigate all our links, images and scripts URLs to check whether we have broken links.
