### PR TITLE
Layout width

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,3 @@ DEPENDENCIES
   octopress-escape-code
   octopress-multilingual
   rouge
-
-BUNDLED WITH
-   1.11.2

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <header class="site-header ">
+  <header class="site-header single-column">
     <a class="blog-title" href="{{ site.baseurl }}/">{{ site.title }}</a>
     <nav class="blog-menu" >
       {% for page in site.pages %}
@@ -8,5 +8,5 @@
         {% endif %}
       {% endfor %}
     </nav>
-  </header>  
+  </header>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@ layout: compress
   {% include head.html %}
   <body>
       {% include header.html %}
-      <main class="container">
+      <main class="container single-column">
         {{ content }}
       </main>
     </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: compress
   <body itemscope itemtype="http://schema.org/BlogPosting">
       {% include header.html %}
       <header class="page-header">
-        <div class="container">
+        <div class="container single-column">
           <h1 itemprop="headline">{{ page.title }}</h1>
           {% include translations.html item=page %}
           <p class="post-meta">
@@ -18,7 +18,7 @@ layout: compress
         </div>
       </header>
 
-      <main class="container">
+      <main class="container single-column">
         <section class="post">
           <span class="hidden" itemprop="publisher">CodeHeaven</span>
           <span class="hidden" itemprop="keywords">{{ page.keywords }}</span>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -8,14 +8,6 @@
   margin: 0 auto;
 }
 
-@media (max-width: 767px) {
-  .single-column {
-    margin-left: 20px;
-    margin-right: 20px;
-    width: auto;
-  }
-}
-
 article {
   a {
     color: #0A7187;
@@ -102,4 +94,28 @@ body {
 
 .talk-media-link {
   color: #4C83B5;
+}
+
+@media (max-width: 767px) {
+
+  .blog-menu {
+    float: initial;
+  }
+  .blog-menu a:first-child {
+    padding: 0 2rem 0 0;
+  }
+
+  .page-header h1 {
+    font-size: 3rem;
+  }
+
+  .single-column {
+    margin-left: 20px;
+    margin-right: 20px;
+    width: auto;
+  }
+
+  .container {
+    padding: 0;
+  }
 }

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,6 +1,19 @@
 .site-header {
   margin: 0;
-  padding: 4rem 0;
+  padding: 3rem 0;
+}
+
+.single-column {
+  width: 700px;
+  margin: 0 auto;
+}
+
+@media (max-width: 767px) {
+  .single-column {
+    margin-left: 20px;
+    margin-right: 20px;
+    width: auto;
+  }
 }
 
 article {
@@ -17,13 +30,14 @@ article {
 b, strong {
   font-family: $bold-font;
 }
+
 .page-header {
   background-color: #f2f2f2;
   padding: 5rem 0;
   margin-bottom: 3rem;
 
   h1 {
-    font-size: 7rem;
+    font-size: 5rem;
     margin-bottom: 0;
   }
 
@@ -34,7 +48,7 @@ b, strong {
 
 .blog-title {
   font-family: $logo-font;
-  font-size: 3rem;
+  font-size: 2.5rem;
 }
 
 .blog-menu {

--- a/_sass/_skeleton.scss
+++ b/_sass/_skeleton.scss
@@ -136,19 +136,19 @@ h1, h2, h3, h4, h5, h6 {
   font-family: $header-font;
   font-weight: 300; }
 h1 { font-size: 4.0rem; line-height: 1.2;  letter-spacing: -.1rem;}
-h2 { font-size: 3.6rem; line-height: 1.25; letter-spacing: -.1rem; }
-h3 { font-size: 3.0rem; line-height: 1.3;  letter-spacing: -.1rem; }
-h4 { font-size: 2.4rem; line-height: 1.35; letter-spacing: -.08rem; }
+h2 { font-size: 3.0rem; line-height: 1.25; letter-spacing: -.1rem; }
+h3 { font-size: 2.8rem; line-height: 1.3;  letter-spacing: -.1rem; }
+h4 { font-size: 2.6rem; line-height: 1.35; letter-spacing: -.08rem; }
 h5 { font-size: 1.8rem; line-height: 1.5;  letter-spacing: -.05rem; }
 h6 { font-size: 1.5rem; line-height: 1.6;  letter-spacing: 0; }
 
 /* Larger than phablet */
 @media (min-width: 550px) {
   h1 { font-size: 5.0rem; }
-  h2 { font-size: 4.2rem; }
-  h3 { font-size: 3.6rem; }
-  h4 { font-size: 3.0rem; }
-  h5 { font-size: 2.4rem; }
+  h2 { font-size: 3.0rem; }
+  h3 { font-size: 2.8rem; }
+  h4 { font-size: 2.6rem; }
+  h5 { font-size: 1.8rem; }
   h6 { font-size: 1.5rem; }
 }
 


### PR DESCRIPTION
I reduced the content width to 700px, to make the posts easier to read. Devices smaller than 767px have their width set to `auto`:
#### Before

![image](https://cloud.githubusercontent.com/assets/2975955/12559307/8e61ace2-c37b-11e5-8eb6-55ec22bf0f03.png)
#### After

![image](https://cloud.githubusercontent.com/assets/2975955/12559318/9c346be8-c37b-11e5-8b42-359181891e07.png)
